### PR TITLE
Fix mob attacks using setHealth

### DIFF
--- a/src/main/java/fathertoast/specialmobs/entity/blaze/EntityEmberBlaze.java
+++ b/src/main/java/fathertoast/specialmobs/entity/blaze/EntityEmberBlaze.java
@@ -70,8 +70,6 @@ class EntityEmberBlaze extends Entity_SpecialBlaze
 	protected
 	void onTypeAttack( Entity target )
 	{
-		if( target instanceof EntityLivingBase ) {
-			((EntityLivingBase) target).setHealth( ((EntityLivingBase) target).getHealth( ) - 2.0F );
-		}
+		target.attackEntityFrom(DamageSource.causeMobDamage(this).setDamageBypassesArmor(), 2.0F);
 	}
 }

--- a/src/main/java/fathertoast/specialmobs/entity/blaze/EntityInfernoBlaze.java
+++ b/src/main/java/fathertoast/specialmobs/entity/blaze/EntityInfernoBlaze.java
@@ -69,8 +69,6 @@ class EntityInfernoBlaze extends Entity_SpecialBlaze
 	protected
 	void onTypeAttack( Entity target )
 	{
-		if( target instanceof EntityLivingBase ) {
-			((EntityLivingBase) target).setHealth( ((EntityLivingBase) target).getHealth( ) - 2.0F );
-		}
+		target.attackEntityFrom(DamageSource.causeMobDamage(this).setDamageBypassesArmor(), 2.0F);
 	}
 }

--- a/src/main/java/fathertoast/specialmobs/entity/ghast/EntityFighterGhast.java
+++ b/src/main/java/fathertoast/specialmobs/entity/ghast/EntityFighterGhast.java
@@ -77,8 +77,6 @@ class EntityFighterGhast extends Entity_SpecialGhast
 	protected
 	void onTypeAttack( Entity target )
 	{
-		if( target instanceof EntityLivingBase ) {
-			((EntityLivingBase) target).setHealth( ((EntityLivingBase) target).getHealth( ) - 2.0F );
-		}
+		target.attackEntityFrom(DamageSource.causeMobDamage(this).setDamageBypassesArmor(), 2.0F);
 	}
 }

--- a/src/main/java/fathertoast/specialmobs/entity/ghast/EntityUnholyGhast.java
+++ b/src/main/java/fathertoast/specialmobs/entity/ghast/EntityUnholyGhast.java
@@ -80,10 +80,8 @@ class EntityUnholyGhast extends Entity_SpecialGhast
 	protected
 	void onTypeAttack( Entity target )
 	{
-		if( target instanceof EntityLivingBase ) {
-			((EntityLivingBase) target).setHealth( ((EntityLivingBase) target).getHealth( ) - 1.0F );
-			heal( 1.0F );
-		}
+		target.attackEntityFrom(DamageSource.causeMobDamage(this).setDamageBypassesArmor(), 1.0F);
+		heal( 1.0F );
 	}
 	
 	@Override

--- a/src/main/java/fathertoast/specialmobs/entity/pigzombie/EntityBrutePigZombie.java
+++ b/src/main/java/fathertoast/specialmobs/entity/pigzombie/EntityBrutePigZombie.java
@@ -70,9 +70,7 @@ class EntityBrutePigZombie extends Entity_SpecialPigZombie
 	protected
 	void onTypeAttack( Entity target )
 	{
-		if( target instanceof EntityLivingBase ) {
-			((EntityLivingBase) target).setHealth( ((EntityLivingBase) target).getHealth( ) - 2.0F );
-		}
+		target.attackEntityFrom(DamageSource.causeMobDamage(this).setDamageBypassesArmor(), 2.0F);
 	}
 	
 	@Nonnull

--- a/src/main/java/fathertoast/specialmobs/entity/pigzombie/EntityVampirePigZombie.java
+++ b/src/main/java/fathertoast/specialmobs/entity/pigzombie/EntityVampirePigZombie.java
@@ -85,10 +85,8 @@ class EntityVampirePigZombie extends Entity_SpecialPigZombie
 	protected
 	void onTypeAttack( Entity target )
 	{
-		if( target instanceof EntityLivingBase ) {
-			((EntityLivingBase) target).setHealth( ((EntityLivingBase) target).getHealth( ) - 2.0F );
-			heal( 2.0F );
-		}
+		target.attackEntityFrom(DamageSource.causeMobDamage(this).setDamageBypassesArmor(), 2.0F);
+		heal( 2.0F );
 	}
 	
 	@Nonnull

--- a/src/main/java/fathertoast/specialmobs/entity/skeleton/EntityBruteSkeleton.java
+++ b/src/main/java/fathertoast/specialmobs/entity/skeleton/EntityBruteSkeleton.java
@@ -70,9 +70,7 @@ class EntityBruteSkeleton extends Entity_SpecialSkeleton
 	protected
 	void onTypeAttack( Entity target )
 	{
-		if( target instanceof EntityLivingBase ) {
-			((EntityLivingBase) target).setHealth( ((EntityLivingBase) target).getHealth( ) - 2.0F );
-		}
+		target.attackEntityFrom(DamageSource.causeMobDamage(this).setDamageBypassesArmor(), 2.0F);
 	}
 	
 	@Nonnull

--- a/src/main/java/fathertoast/specialmobs/entity/witherskeleton/EntityBruteWitherSkeleton.java
+++ b/src/main/java/fathertoast/specialmobs/entity/witherskeleton/EntityBruteWitherSkeleton.java
@@ -70,9 +70,7 @@ class EntityBruteWitherSkeleton extends Entity_SpecialWitherSkeleton
 	protected
 	void onTypeAttack( Entity target )
 	{
-		if( target instanceof EntityLivingBase ) {
-			((EntityLivingBase) target).setHealth( ((EntityLivingBase) target).getHealth( ) - 2.0F );
-		}
+		target.attackEntityFrom(DamageSource.causeMobDamage(this).setDamageBypassesArmor(), 2.0F);
 	}
 	
 	@Nonnull

--- a/src/main/java/fathertoast/specialmobs/entity/zombie/EntityBruteZombie.java
+++ b/src/main/java/fathertoast/specialmobs/entity/zombie/EntityBruteZombie.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.projectile.EntityTippedArrow;
 import net.minecraft.init.Items;
 import net.minecraft.init.MobEffects;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 
@@ -70,9 +71,7 @@ class EntityBruteZombie extends Entity_SpecialZombie
 	protected
 	void onTypeAttack( Entity target )
 	{
-		if( target instanceof EntityLivingBase ) {
-			((EntityLivingBase) target).setHealth( ((EntityLivingBase) target).getHealth( ) - 2.0F );
-		}
+		target.attackEntityFrom(DamageSource.causeMobDamage(this).setDamageBypassesArmor(), 2.0F);
 	}
 	
 	@Nonnull


### PR DESCRIPTION
Fix several mobs using `setHealth` to directly decrease the target's health.

This method bypasses death, causing several errors with other mods, and even the player itself, when the entity falls below 0 health as a result of these mobs attacking.

As such, this PR fixes that by using attackEntityFrom with an armor-bypassing damage source, applying direct damage to the entity while still calling death and other hurt-related actions properly.